### PR TITLE
Improved embedding extraction in README for smoother workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ To extract vision embeddings using the CT models, please refer to the example me
 ```bash
 uv run rate-extract \
     --model pillar0 \
-    --dataset rve_chest_ct \ # rve_abd_ct, rve_brain_ct, rve_chest_ct 
+    --dataset rve_chest_ct \ 
     --split train \
     --batch-size 4 \
-    --model-repo-id YalaLab/Pillar0-ChestCT \ # YalaLab/Pillar0-AbdomenCT, YalaLab/Pillar0-BrainCT, YalaLab/Pillar0-ChestCT 
+    --model-repo-id YalaLab/Pillar0-ChestCT \
     --ct-window-type all \
     --output-dir /path/to/cache \
     data.train_json=/path/to/json \
@@ -101,6 +101,8 @@ uv run rate-extract \
    - `train.json`: JSON file with sample metadata (e.g., `{"sample_name": "EXAMPLE_ACCESSION", "nii_path": null, "report_metadata": "FINDINGS: ..."}`)
    - `manifest.csv`: CSV mapping samples to cached volumes (columns: `sample_name`, `image_cache_path`)
    - Volume directories: Each volume should be in a directory with `volume.mp4` and `metadata.json`
+3. **Dataset options include**: `rve_abd_ct`, `rve_brain_ct`, `rve_chest_ct`
+4. **Model repo options include**: `YalaLab/Pillar0-AbdomenCT`, `YalaLab/Pillar0-BrainCT`, `YalaLab/Pillar0-ChestCT`
 
 ## Troubleshooting
 ### Common Issues


### PR DESCRIPTION
The comments in the bash required manual deletion which may have caused problems (e.g., extra spaces which caused the script not to work). Added the comment contents to "Key points" section.